### PR TITLE
fix windows build on non-cl compilers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ tcc_env
 tcc_env.*
 cmake_env.bat
 cmake_env.sh
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,8 @@ else()
     add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
     if(CMAKE_C_SIMULATE_ID MATCHES "MSVC")
         add_definitions("/wd4244 /wd4267 /wd4033 /wd4715 /wd4996")
+    else()
+        add_definitions(-Wno-string-plus-int -Wno-pointer-sign -Wno-shift-negative-value)
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,9 @@ if(UNIX)
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")
 else()
     add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
-    add_definitions("/wd4244 /wd4267 /wd4033 /wd4715 /wd4996")
+    if(CMAKE_C_SIMULATE_ID MATCHES "MSVC")
+        add_definitions("/wd4244 /wd4267 /wd4033 /wd4715 /wd4996")
+    endif()
 endif()
 
 set(TCC_VERSION ${PROJECT_VERSION})
@@ -374,7 +376,10 @@ set_target_properties(libtcc PROPERTIES
 # TCC compiler as executable
 
 if(WIN32)
-    add_definitions(-W2 -MT -GS- -nologo -D_CRT_SECURE_NO_DEPRECATE)
+    add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
+    if(CMAKE_C_SIMULATE_ID MATCHES "MSVC")
+        add_definitions(-W2 -MT -GS- -nologo)
+    endif()
 endif()
 
 add_executable(tcc ${SRC_DIR}/tcc.c)

--- a/src/threads/rpmalloc.c
+++ b/src/threads/rpmalloc.c
@@ -262,81 +262,81 @@ make_atomic(unsigned int, atomic32_t)
 make_atomic(unsigned long long, atomic64_t)
 
 #if defined(__TINYC__) && (defined(__arm__) || defined(__aarch64__) || defined(__riscv))
-static FORCEINLINE int32_t atomic_load32(atomic32_t *src) {
+FORCEINLINE int32_t atomic_load32(atomic32_t *src) {
     return atomic_load_explicit((volatile c89atomic_uint32 *)src, memory_order_relaxed);
 }
-static FORCEINLINE void atomic_store32(atomic32_t *dst, int32_t val) {
+FORCEINLINE void atomic_store32(atomic32_t *dst, int32_t val) {
     atomic_store_explicit((volatile c89atomic_uint32 *)dst, (c89atomic_uint32)val, memory_order_relaxed);
 }
-static FORCEINLINE int32_t atomic_incr32(atomic32_t *val) {
+FORCEINLINE int32_t atomic_incr32(atomic32_t *val) {
     return atomic_fetch_add_explicit((volatile c89atomic_uint32 *)val, 1, memory_order_relaxed) + 1;
 }
-static FORCEINLINE int32_t atomic_decr32(atomic32_t *val) {
+FORCEINLINE int32_t atomic_decr32(atomic32_t *val) {
     return atomic_fetch_add_explicit((volatile c89atomic_uint32 *)val, -1, memory_order_relaxed) - 1;
 }
-static FORCEINLINE int32_t atomic_add32(atomic32_t *val, int32_t add) {
+FORCEINLINE int32_t atomic_add32(atomic32_t *val, int32_t add) {
     return atomic_fetch_add_explicit((volatile c89atomic_uint32 *)val, (c89atomic_uint32)add, memory_order_relaxed) + add;
 }
-static FORCEINLINE int atomic_cas32_acquire(atomic32_t *dst, int32_t val, int32_t ref) {
+FORCEINLINE int atomic_cas32_acquire(atomic32_t *dst, int32_t val, int32_t ref) {
     return atomic_compare_exchange_weak_explicit((volatile c89atomic_uint32 *)dst, &ref, (c89atomic_uint32)val, memory_order_acquire, memory_order_relaxed);
 }
-static FORCEINLINE void atomic_store32_release(atomic32_t *dst, int32_t val) {
+FORCEINLINE void atomic_store32_release(atomic32_t *dst, int32_t val) {
     atomic_store_explicit((volatile c89atomic_uint32 *)dst, (c89atomic_uint32)val, memory_order_release);
 }
 #else
-static FORCEINLINE int32_t atomic_load32(atomic32_t *src) {
+FORCEINLINE int32_t atomic_load32(atomic32_t *src) {
     return c89atomic_load_explicit_32(src, memory_order_relaxed);
 }
-static FORCEINLINE void atomic_store32(atomic32_t *dst, int32_t val) {
+FORCEINLINE void atomic_store32(atomic32_t *dst, int32_t val) {
     c89atomic_store_explicit_32(dst, val, memory_order_relaxed);
 }
-static FORCEINLINE int32_t atomic_incr32(atomic32_t *val) {
+FORCEINLINE int32_t atomic_incr32(atomic32_t *val) {
     return c89atomic_fetch_add_explicit_32(val, 1, memory_order_relaxed) + 1;
 }
-static FORCEINLINE int32_t atomic_decr32(atomic32_t *val) {
+FORCEINLINE int32_t atomic_decr32(atomic32_t *val) {
     return c89atomic_fetch_add_explicit_32(val, -1, memory_order_relaxed) - 1;
 }
-static FORCEINLINE int32_t atomic_add32(atomic32_t *val, int32_t add) {
+FORCEINLINE int32_t atomic_add32(atomic32_t *val, int32_t add) {
     return c89atomic_fetch_add_explicit_32(val, add, memory_order_relaxed) + add;
 }
-static FORCEINLINE int atomic_cas32_acquire(atomic32_t *dst, int32_t val, int32_t ref) {
+FORCEINLINE int atomic_cas32_acquire(atomic32_t *dst, int32_t val, int32_t ref) {
     return c89atomic_compare_exchange_weak_explicit_32(dst, &ref, val, memory_order_acquire, memory_order_relaxed);
 }
-static FORCEINLINE void atomic_store32_release(atomic32_t *dst, int32_t val) {
+FORCEINLINE void atomic_store32_release(atomic32_t *dst, int32_t val) {
     c89atomic_store_explicit_32(dst, val, memory_order_release);
 }
 #endif
 
 #if defined(__arm__)
-static FORCEINLINE void *atomic_load_ptr(atomic_ptr_t *src) {
+FORCEINLINE void *atomic_load_ptr(atomic_ptr_t *src) {
     return (void *)atomic_load_explicit(src, memory_order_relaxed);
 }
-static FORCEINLINE void atomic_store_ptr(atomic_ptr_t *dst, void *val) {
+FORCEINLINE void atomic_store_ptr(atomic_ptr_t *dst, void *val) {
     atomic_store_explicit(dst, val, memory_order_relaxed);
 }
-static FORCEINLINE void atomic_store_ptr_release(atomic_ptr_t *dst, void *val) {
+FORCEINLINE void atomic_store_ptr_release(atomic_ptr_t *dst, void *val) {
     atomic_store_explicit(dst, val, memory_order_release);
 }
-static FORCEINLINE void *atomic_exchange_ptr_acquire(atomic_ptr_t *dst, void *val) {
+FORCEINLINE void *atomic_exchange_ptr_acquire(atomic_ptr_t *dst, void *val) {
     return (void *)atomic_exchange_explicit(dst, val, memory_order_acquire);
 }
-static FORCEINLINE int atomic_cas_ptr(atomic_ptr_t *dst, void *val, void *ref) {
+FORCEINLINE int atomic_cas_ptr(atomic_ptr_t *dst, void *val, void *ref) {
     return (int)atomic_swap(dst, &ref, val);
 }
 #else
-static FORCEINLINE void *atomic_load_ptr(atomic_ptr_t *src) {
+FORCEINLINE void *atomic_load_ptr(atomic_ptr_t *src) {
     return (void *)c89atomic_load_explicit_64((volatile c89atomic_uint64 *)src, memory_order_relaxed);
 }
-static FORCEINLINE void atomic_store_ptr(atomic_ptr_t *dst, void *val) {
+FORCEINLINE void atomic_store_ptr(atomic_ptr_t *dst, void *val) {
     c89atomic_store_explicit_64((volatile c89atomic_uint64 *)dst, (c89atomic_uint64)val, memory_order_relaxed);
 }
-static FORCEINLINE void atomic_store_ptr_release(atomic_ptr_t *dst, void *val) {
+FORCEINLINE void atomic_store_ptr_release(atomic_ptr_t *dst, void *val) {
     c89atomic_store_explicit_64((volatile c89atomic_uint64 *)dst, (c89atomic_uint64)val, memory_order_release);
 }
-static FORCEINLINE void *atomic_exchange_ptr_acquire(atomic_ptr_t *dst, void *val) {
+FORCEINLINE void *atomic_exchange_ptr_acquire(atomic_ptr_t *dst, void *val) {
     return (void *)c89atomic_exchange_explicit_64((volatile c89atomic_uint64 *)dst, (c89atomic_uint64)val, memory_order_acquire);
 }
-static FORCEINLINE int atomic_cas_ptr(atomic_ptr_t *dst, void *val, void *ref) {
+FORCEINLINE int atomic_cas_ptr(atomic_ptr_t *dst, void *val, void *ref) {
     return (int)atomic_swap((volatile c89atomic_uint64 *)dst, (c89atomic_uint64 *)&ref, (c89atomic_uint64)val);
 }
 #endif


### PR DESCRIPTION
Unsure how correct the changes in `rpmalloc.c` are, without the change the clang fails with the error `cannot combine with previous 'static' declaration specifier`, haven't tested it with MSVC.
The changes in `CMakeLists.txt` seem to work both on clang and gcc.